### PR TITLE
Use interface methods to segment services

### DIFF
--- a/messaging.go
+++ b/messaging.go
@@ -39,13 +39,13 @@ type MessagingService struct {
 }
 
 func (s *MessagingService) SendMessages(ctx context.Context, r *SendMessagesRequest) (*Response, error) {
-	req, err := s.client.newRequest(http.MethodPost, messagingMessagesSendPath, r)
+	req, err := s.client.http.newRequest(http.MethodPost, messagingMessagesSendPath, r)
 	if err != nil {
 		return nil, err
 	}
 
 	var res Response
-	if err := s.client.do(ctx, req, &res); err != nil {
+	if err := s.client.http.do(ctx, req, &res); err != nil {
 		return nil, err
 	}
 
@@ -53,13 +53,13 @@ func (s *MessagingService) SendMessages(ctx context.Context, r *SendMessagesRequ
 }
 
 func (s *MessagingService) TriggerCampaign(ctx context.Context, r *TriggerCampaignRequest) (*Response, error) {
-	req, err := s.client.newRequest(http.MethodPost, messagingCampaignsTriggerSendPath, r)
+	req, err := s.client.http.newRequest(http.MethodPost, messagingCampaignsTriggerSendPath, r)
 	if err != nil {
 		return nil, err
 	}
 
 	var res Response
-	if err := s.client.do(ctx, req, &res); err != nil {
+	if err := s.client.http.do(ctx, req, &res); err != nil {
 		return nil, err
 	}
 

--- a/preferencecenter.go
+++ b/preferencecenter.go
@@ -47,7 +47,7 @@ func (s *PreferenceCenterService) CreateURL(ctx context.Context, r *PreferenceCe
 
 	path := fmt.Sprintf("/preference_center/v1/%s/url/%s", r.PreferenceCenterID, r.UserID)
 
-	req, err := s.client.newRequest(http.MethodPost, path, r)
+	req, err := s.client.http.newRequest(http.MethodPost, path, r)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (s *PreferenceCenterService) CreateURL(ctx context.Context, r *PreferenceCe
 		URL string `json:"preference_center_url"`
 	}{}
 
-	if err := s.client.do(ctx, req, &resp); err != nil {
+	if err := s.client.http.do(ctx, req, &resp); err != nil {
 		return nil, err
 	}
 

--- a/preferencecenter_test.go
+++ b/preferencecenter_test.go
@@ -28,7 +28,7 @@ func TestPreferencesServerCreateURL(t *testing.T) {
 	client, err := braze.NewClient(braze.APIKey("key"), braze.BaseURL(url))
 	assert.NoError(t, err)
 
-	resp, err := client.PreferenceCenter.CreateURL(context.Background(), &braze.PreferenceCenterCreateURLRequest{
+	resp, err := client.PreferenceCenter().CreateURL(context.Background(), &braze.PreferenceCenterCreateURLRequest{
 		PreferenceCenterID: "foo",
 		UserID:             "bar",
 	})
@@ -52,7 +52,7 @@ func TestPreferencesServerCreateURLInternalServerError(t *testing.T) {
 	client, err := braze.NewClient(braze.APIKey("key"), braze.BaseURL(url))
 	assert.NoError(t, err)
 
-	resp, err := client.PreferenceCenter.CreateURL(context.Background(), nil)
+	resp, err := client.PreferenceCenter().CreateURL(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }

--- a/users.go
+++ b/users.go
@@ -202,13 +202,13 @@ type UserEvent struct {
 type UserPurchase struct{}
 
 func (s *UsersService) Track(ctx context.Context, r *UsersTrackRequest) (*Response, error) {
-	req, err := s.client.newRequest(http.MethodPost, usersTrackPath, r)
+	req, err := s.client.http.newRequest(http.MethodPost, usersTrackPath, r)
 	if err != nil {
 		return nil, err
 	}
 
 	var res Response
-	if err := s.client.do(ctx, req, &res); err != nil {
+	if err := s.client.http.do(ctx, req, &res); err != nil {
 		return nil, err
 	}
 
@@ -216,13 +216,13 @@ func (s *UsersService) Track(ctx context.Context, r *UsersTrackRequest) (*Respon
 }
 
 func (s *UsersService) Delete(ctx context.Context, r *UsersDeleteRequest) (*Response, error) {
-	req, err := s.client.newRequest(http.MethodPost, usersDeletePath, r)
+	req, err := s.client.http.newRequest(http.MethodPost, usersDeletePath, r)
 	if err != nil {
 		return nil, err
 	}
 
 	var res Response
-	if err := s.client.do(ctx, req, &res); err != nil {
+	if err := s.client.http.do(ctx, req, &res); err != nil {
 		return nil, err
 	}
 

--- a/users_test.go
+++ b/users_test.go
@@ -49,7 +49,7 @@ func TestUsersServiceTrack(t *testing.T) {
 		}),
 	)
 
-	resp, err := client.Users.Track(context.Background(), &braze.UsersTrackRequest{
+	resp, err := client.Users().Track(context.Background(), &braze.UsersTrackRequest{
 		Attributes: []*braze.UserAttributes{
 			attr,
 			// This is expected to return a minor error.
@@ -79,7 +79,7 @@ func TestUsersServiceTrackInternalServerError(t *testing.T) {
 	client, err := braze.NewClient(braze.APIKey("key"), braze.BaseURL(url))
 	assert.NoError(t, err)
 
-	resp, err := client.Users.Track(context.Background(), nil)
+	resp, err := client.Users().Track(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
@@ -106,7 +106,7 @@ func TestUsersServiceTrackCustomAttributes(t *testing.T) {
 	}
 	attr.AddAttributes(braze.BoolAttribute("testing", true))
 
-	resp, err := client.Users.Track(context.Background(), &braze.UsersTrackRequest{
+	resp, err := client.Users().Track(context.Background(), &braze.UsersTrackRequest{
 		Attributes: []*braze.UserAttributes{attr},
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
To simplify stubbing the Braze interface.